### PR TITLE
Remove a duplicate msgid "" from libdnf5-cli/sv.po

### DIFF
--- a/libdnf5-cli/sv.po
+++ b/libdnf5-cli/sv.po
@@ -117,26 +117,6 @@ msgstr "Operation avbröts av användaren."
 msgid "Failed to resolve the transaction"
 msgstr "Misslyckades att lösa transaktionen"
 
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#: exception.cpp:49
-#, fuzzy
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 02:52+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: 8bit\n"
-
 #: session.cpp:79
 msgid "Missing command"
 msgstr "Saknar kommando"


### PR DESCRIPTION
Duplicate message IDs are a fatal error for GNU gettext.