### PR TITLE
libdnf5-cli: Remove duplicate header

### DIFF
--- a/libdnf5-cli/pt_BR.po
+++ b/libdnf5-cli/pt_BR.po
@@ -116,26 +116,6 @@ msgstr "Operação abortada pelo usuário."
 msgid "Failed to resolve the transaction"
 msgstr "Falha ao resolver a transação"
 
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#: exception.cpp:49
-#, fuzzy
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 02:52+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: 8bit\n"
-
 #: session.cpp:79
 msgid "Missing command"
 msgstr "Faltando comando"

--- a/libdnf5-cli/sv.po
+++ b/libdnf5-cli/sv.po
@@ -117,26 +117,6 @@ msgstr "Operation avbröts av användaren."
 msgid "Failed to resolve the transaction"
 msgstr "Misslyckades att lösa transaktionen"
 
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#: exception.cpp:49
-#, fuzzy
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 02:52+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: 8bit\n"
-
 #: session.cpp:79
 msgid "Missing command"
 msgstr "Saknar kommando"


### PR DESCRIPTION
Fix rpm-software-management/dnf5#1158, based in rpm-software-management/dnf5#1162

Fixing in dnf5 was not enough. While the POT was fixed, the translations still presented the issue and were not able to be renewed [in Weblate with the messages below](https://translate.fedoraproject.org/projects/dnf5/libdnf5-cli/#alerts):

The command is: `msgmerge --previous --output-file <po_file> libdnf5-cli.pot`

The error is:

```
/home/weblate/data/vcs/dnf5/dnf5/libdnf5-cli/pt_BR.po: warning: Charset "CHARSET" is not a portable encoding name.
                                                                Message conversion to user's charset might not work.
/home/weblate/data/vcs/dnf5/dnf5/libdnf5-cli/pt_BR.po:126: duplicate message definition...
/home/weblate/data/vcs/dnf5/dnf5/libdnf5-cli/pt_BR.po:3: ...this is the location of the first definition
msgmerge: found 1 fatal error
```

```
/home/weblate/data/vcs/dnf5/dnf5/libdnf5-cli/sv.po: warning: Charset "CHARSET" is not a portable encoding name.
                                                             Message conversion to user's charset might not work.
/home/weblate/data/vcs/dnf5/dnf5/libdnf5-cli/sv.po:127: duplicate message definition...
/home/weblate/data/vcs/dnf5/dnf5/libdnf5-cli/sv.po:4: ...this is the location of the first definition
msgmerge: found 1 fatal error
```